### PR TITLE
Add fragment midpoint info to HitCache with relevant methods

### DIFF
--- a/src/org/seqcode/deepseq/experiments/ExperimentCondition.java
+++ b/src/org/seqcode/deepseq/experiments/ExperimentCondition.java
@@ -76,6 +76,17 @@ public class ExperimentCondition {
 			total += s.getHitCount();
 		return total;
 	}
+	
+	/**
+	 *Get total weight pair count for signal samples 
+	 */
+	public double getTotalSignalPairCount() {
+		double total=0;
+		for(Sample s: signalSamples)
+			total += s.getPairCount();
+		return total;
+	}
+	
 	/**
 	 * Get the total weight count for signal samples from one strand
 	 * @return
@@ -88,7 +99,7 @@ public class ExperimentCondition {
 	}
 		
 	/**
-	 * Get the total weight count for signal samples
+	 * Get the total weight count for control samples
 	 * @return
 	 */
 	public double getTotalControlCount(){
@@ -97,6 +108,17 @@ public class ExperimentCondition {
 			total += s.getHitCount();
 		return total;
 	}
+	
+	/**
+	 *Get total weight pair count for control samples 
+	 */
+	public double getTotalControlPairCount() {
+		double total=0;
+		for(Sample s: controlSamples)
+			total += s.getPairCount();
+		return total;
+	}
+	
 	/**
 	 * Get the total weight count for control samples from one strand
 	 * @return
@@ -117,6 +139,17 @@ public class ExperimentCondition {
 		for(ControlledExperiment rep : replicates){
 			s+=rep.getSignal().getHitCount()*rep.getSignalVsNoiseFraction();
 		}return(s/getTotalSignalCount());
+	}
+	
+	/**
+	 * Get the pooled signal pair fraction from all underlying signal channels
+	 */
+	public double getTotalSignalPairVsNoisePairFrac() {
+		double s=0;
+		for(ControlledExperiment rep: replicates) {
+			s += rep.getSignal().getPairCount() * rep.getSignalVsNoiseFraction();
+		}
+		return (s/getTotalSignalPairCount());
 	}
 	
 	/**

--- a/src/org/seqcode/deepseq/experiments/ExperimentManager.java
+++ b/src/org/seqcode/deepseq/experiments/ExperimentManager.java
@@ -246,14 +246,23 @@ public class ExperimentManager {
 				for(ControlledExperiment r : cond.getReplicates()){
 					System.err.println("\tReplicate:\t"+r.getName());
 					if(r.getControl()==null)
-						System.err.println(String.format("\t\tSignal:\t%.1f", r.getSignal().getHitCount()));
+						System.err.println(String.format("\t\tSignal:\t%.1f pairs, %.1f hits", r.getSignal().getPairCount(), r.getSignal().getHitCount()));
 					else
-						System.err.println(String.format("\t\tSignal:\t%.1f\tControl:\t%.1f\tScalingFactor:\t%.3f",  r.getSignal().getHitCount(), r.getControl().getHitCount(), r.getControlScaling()));
+						System.err.println(String.format("\t\tSignal:\t%.1f pairs, %.1f hits\tControl:\t%.1f pairs, %.1f hits\tScalingFactor:\t%.3f",  
+								r.getSignal().getPairCount(), r.getSignal().getHitCount(), 
+								r.getSignal().getPairCount(), r.getControl().getHitCount(), 
+								r.getControlScaling()));
 				}
 				if(cond.getTotalControlCount()>0)
-					System.err.println(String.format("\tPooled replicates for condition:\t%s\n\t\tSignal:\t%.1f\tControl:%.1f\tScalingFactor:%.3f",cond.getName(), cond.getTotalSignalCount(), cond.getTotalControlCount(), cond.getPooledSampleControlScaling()));
+					System.err.println(String.format("\tPooled replicates for condition:\t%s\n\t\tSignal:\t%.1f pairs, %.1f hits\tControl:%.1f pairs, %.1f hits\tScalingFactor:%.3f",
+							cond.getName(), 
+							cond.getTotalSignalPairCount(), cond.getTotalSignalCount(), 
+							cond.getTotalControlPairCount(), cond.getTotalControlCount(), 
+							cond.getPooledSampleControlScaling()));
 				else
-					System.err.println(String.format("\tPooled replicates for condition:\t%s\n\t\tSignal:\t%.1f",cond.getName(), cond.getTotalSignalCount()));
+					System.err.println(String.format("\tPooled replicates for condition:\t%s\n\t\tSignal:\t%.1f pairs, %.1f hits",
+							cond.getName(), 
+							cond.getTotalSignalPairCount(), cond.getTotalSignalCount()));
 			}
 		}
 

--- a/src/org/seqcode/deepseq/experiments/ExptConfig.java
+++ b/src/org/seqcode/deepseq/experiments/ExptConfig.java
@@ -56,6 +56,7 @@ public class ExptConfig {
 	protected boolean loadType2Reads = false; //Load Type2 reads (if exists and distinguishable)
 	protected boolean loadRead2=true; //Load second in pair reads (only used by BAM loader for now)
 	protected boolean loadPairs = false; //Load pair information (if exists)
+	protected boolean sortMid = false; //Sort pairs according to midpoint
 	protected double NCISMinBinFrac = 0.75; //NCIS estimates begin using the lower fraction of the genome (based on total tags)
 	
 	    
@@ -112,6 +113,7 @@ public class ExptConfig {
 				loadType1Reads = !Args.parseFlags(args).contains("not1reads");
 				loadType2Reads = Args.parseFlags(args).contains("loadt2reads");
 				loadRead2 = !Args.parseFlags(args).contains("noread2");
+				sortMid = Args.parseArgs(args).contains("sortMid");
 				
 				////////////////////////
 				//Read limit parameters
@@ -332,6 +334,7 @@ public class ExptConfig {
 	public void setLoadType2Reads(boolean l){loadType2Reads = l;}
 	public void setLoadRead2(boolean l){loadRead2 = l;}
 	public void setLoadPairs(boolean l){loadPairs = l;}
+	public void setSortMid(boolean l) {sortMid = l;}
 	
 	
 	/**
@@ -384,6 +387,7 @@ public class ExptConfig {
 				"\t--nocache [flag to turn off caching of the entire set of experiments (i.e. run slower with less memory)]\n" +
 				"\t--not1reads / --loadt2reads [flags to use Type1 or Type2 reads] (Type1 loaded by default)\n" +
 				"\t--noread2 [flag to ignore second reads in paired-end]\n" +
+				"\t--sortMid [flag to decide if sort read pairs by midpoint or 5' end (default: 5' end)]\n" +
 				""));
 	}
 }

--- a/src/org/seqcode/deepseq/experiments/HitCache.java
+++ b/src/org/seqcode/deepseq/experiments/HitCache.java
@@ -323,6 +323,30 @@ public class HitCache {
 		System.gc();
 	}
 	
+	/**
+	 * Generate a hashmap containing the frequencies of each fragment size,
+	 * @return
+	 * @author Jianyu Yang
+	 */
+	public HashMap<Integer, Integer> getFragSizeFrequency(){
+		HashMap<Integer, Integer> frequency = new HashMap<Integer, Integer>();
+		for(int chrID=0; chrID<pairR1Pos.length; chrID++)
+			for(int strand=0; strand<pairR1Pos[chrID].length; strand++)
+				for(int index=0; index<pairR1Pos[chrID][strand].length; index++)
+					if(chrID==pairR2Chrom[chrID][strand][index]) { 
+						int size = Math.abs(pairR1Pos[chrID][strand][index]-pairR2Pos[chrID][strand][index]+1);
+						if(frequency.containsKey(size)) {
+							int oldValue = frequency.get(size);
+							int newValue = oldValue + 1;
+							frequency.put(size, newValue);
+						} else {
+							frequency.put(size, 1);
+						}
+					}
+		
+		return frequency;
+	}
+	
 	
 	/**
 	 * Load all base counts in a region, regardless of strand.

--- a/src/org/seqcode/deepseq/experiments/HitCache.java
+++ b/src/org/seqcode/deepseq/experiments/HitCache.java
@@ -95,6 +95,7 @@ public class HitCache {
 	protected double uniquePairs=0; //count of the total number of unique paired hits
 	protected boolean loadPairs; //Load them if they exist
 	protected boolean hasPairs; //Some pairs have been loaded
+	protected boolean sortMid; //Sort pairs according to midpoint
 	protected BackgroundCollection perBaseBack=new BackgroundCollection();
 	protected float maxReadsPerBP=-1;
 	
@@ -181,6 +182,7 @@ public class HitCache {
 		this.loaders = hloaders;
 		maxReadsPerBP= perBaseReadMax;
 		this.loadPairs = loadPairs;
+		this.sortMid = ec.sortMid;
 		initialize(cacheEverything, initialCacheRegions);
 	}
 	
@@ -768,12 +770,16 @@ public class HitCache {
 				}
 			}
 		}
-		//Sort the paired-end arrays !!!!!!!!!!ATTENTION!!!!!!!!!!!!!: I need to sort by midpoint here
+		//Sort the paired-end arrays
 		if(loadPairs && hasPairs){ 
 			for(int i = 0; i < pairR1Pos.length; i++) {  // chr
 				for(int j = 0; j < pairR1Pos[i].length; j++) { // strand
 					if(pairR1Pos[i][j]!=null && pairR2Pos[i][j]!=null && pairR2Chrom[i][j]!=null && pairR2Strand[i][j]!=null){
-						int[] inds = StatUtil.findSort(pairMid[i][j]);
+						int[] inds;
+						if (sortMid)
+							inds = StatUtil.findSort(pairMid[i][j]);
+						else
+							inds = StatUtil.findSort(pairR1Pos[i][j]);
 						pairR1Pos[i][j] = StatUtil.permute(pairR1Pos[i][j], inds);
 						pairR2Pos[i][j] = StatUtil.permute(pairR2Pos[i][j], inds);
 						pairR2Chrom[i][j] = StatUtil.permute(pairR2Chrom[i][j], inds);

--- a/src/org/seqcode/deepseq/experiments/Sample.java
+++ b/src/org/seqcode/deepseq/experiments/Sample.java
@@ -132,6 +132,10 @@ public class Sample {
 		return cache.getPairs(r);
 	}
 	
+	public List<StrandedPair> getPairsByMid(Region r) {
+		return cache.getPairsByMid(r);
+	}
+	
 	/**
 	 * Sum of all hit weights in a region.
 	 * If caching in local files, group calls to this method by same chromosome.

--- a/src/org/seqcode/deepseq/experiments/Sample.java
+++ b/src/org/seqcode/deepseq/experiments/Sample.java
@@ -3,6 +3,7 @@ package org.seqcode.deepseq.experiments;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.HashMap;
 
 import org.seqcode.deepseq.ExtReadHit;
 import org.seqcode.deepseq.ReadHit;
@@ -90,6 +91,15 @@ public class Sample {
 		uniquePairs = cache.getUniquePairCount();
 		if(gen==null)
 			gen = cache.getGenome();
+	}
+	
+	/**
+	 * Load fragment size frequency
+	 * @return
+	 * @author Jianyu Yang
+	 */
+	public HashMap<Integer, Integer> getFragSizeFrequency() {
+		return cache.getFragSizeFrequency();
 	}
 	
 	

--- a/src/org/seqcode/deepseq/stats/BackgroundCollection.java
+++ b/src/org/seqcode/deepseq/stats/BackgroundCollection.java
@@ -1,6 +1,7 @@
 package org.seqcode.deepseq.stats;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.seqcode.genome.location.Region;
 

--- a/src/org/seqcode/deepseq/stats/PoissonBackgroundModel.java
+++ b/src/org/seqcode/deepseq/stats/PoissonBackgroundModel.java
@@ -42,7 +42,7 @@ public class PoissonBackgroundModel extends BackgroundModel{
 		for(int b=1; l>confThreshold; b++){
 			l=1-P.cdf(b);
 			countThres=b;
-		}
+		}	
 		return(Math.max(1,countThres));
 	}
 	


### PR DESCRIPTION
New features:

1.Add a new `pairMid` array to store midpoint location of fragment, it uses the same index as other array.
2.Now populateArrays can use `pairMid` to sort reads, this is useful for algorithm like SEM to get reads by the location of fragment midpoint. Sorting behavior is controlled by `sortMid` parameter in `ExperimentConfig`, by default it uses `pairR1Pos` to sort arrays to ensure backward compatibility
3.Several relevant methods on getting `strandedPair` counts, fragment size frequency, etc.